### PR TITLE
Basic specimen matching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ install:
 
 # command to run tests
 script:
-  - travis_wait 40 py.test
+  - travis_wait 40 py.test ./tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,5 @@ install:
 
 # command to run tests
 script:
+  - cd testcase2owl; python -m pytest; cd ..
   - travis_wait 40 py.test ./tests

--- a/testcase2owl/paper-context.json
+++ b/testcase2owl/paper-context.json
@@ -169,8 +169,10 @@
             "@type": "@set"
         },
 
-        "== Properties of individual OTUs ==": {},
+        "== Properties of individual TUs ==": {},
         "dwc": "http://rs.tdwg.org/dwc/terms/",
+
+        "=== Scientific names ===": {},
 
         "scientificName": {
             "@id": "dwc:scientificName",
@@ -188,6 +190,13 @@
             "@id": "dwc:specificEpithet",
             "@type": "xsd:string"
         },
+
+        "=== Specimen identifiers ===": {},
+
+        "occurrenceID": "dwc:occurrenceID",
+        "catalogNumber": "dwc:catalogNumber",
+        "collectionCode": "dwc:collectionCode",
+        "institutionCode": "dwc:institutionCode",
 
         "subClassOf": {
             "@id": "rdfs:subClassOf",

--- a/testcase2owl/phyloref/Phylogeny.py
+++ b/testcase2owl/phyloref/Phylogeny.py
@@ -128,6 +128,14 @@ class Phylogeny(object):
                     if 'additionalLabels' in node.additional_properties:
                         node_label_strs.extend(node.additional_properties['additionalLabels'])
 
+                    # Does the additional_node_properties have additional tunits?
+                    if 'representsTaxonomicUnits' in node.additional_properties:
+                        for tunit_jsonld in node.additional_properties['representsTaxonomicUnits']:
+                            tunit = TaxonomicUnit.from_jsonld(tunit_jsonld)
+                            tunit.id = self.get_id_for_node(dendropy_node) + ("_tunit%d" % tunit_count)
+                            tunits.append(tunit)
+                            tunit_count += 1
+
                 if node_label.annotations:
                     for closeMatch in node_label.annotations.findall(name='closeMatch'):
                         node_label_strs.append(closeMatch.value)
@@ -142,9 +150,6 @@ class Phylogeny(object):
                 tunit.id = self.get_id_for_node(dendropy_node) + ("_tunit%d" % tunit_count)
                 tunits.append(tunit)
                 tunit_count += 1
-
-                # TODO: check node.additional_properties and see if the user has provided
-                # specimen or scientific name information.
 
             # Store discovered taxonomic units.
             node.taxonomic_units.extend(tunits)
@@ -239,6 +244,9 @@ class Node(Identified):
 
         # Add additional properties
         for key in self.additional_properties:
-            jsonld[key] = self.additional_properties[key]
+            if key in jsonld:
+                jsonld[key].append(self.additional_properties[key])
+            else:
+                jsonld[key] = self.additional_properties[key]
 
         return jsonld

--- a/testcase2owl/phyloref/Phylogeny.py
+++ b/testcase2owl/phyloref/Phylogeny.py
@@ -243,9 +243,19 @@ class Node(Identified):
             jsonld['expectedPhyloreferenceNamed'] = self.expected_phyloref_named
 
         # Add additional properties
+        #
+        # Note that this duplicates taxonomic units added through the additional properties list,
+        # which are first added above (as TaxonomicUnits) and then added again through additional properties.
+        # There isn't a straightforward way to deduplicate them, and I like the idea of those additional
+        # properties being explicitly visible, as they could be useful for debugging if there are properties
+        # in additional properties that were misread or ignored by the TaxonomicUnit processing.
+        #
         for key in self.additional_properties:
             if key in jsonld:
-                jsonld[key].append(self.additional_properties[key])
+                if isinstance(self.additional_properties[key], list):
+                    jsonld[key].extend(self.additional_properties[key])
+                else:
+                    jsonld[key].append(self.additional_properties[key])
             else:
                 jsonld[key] = self.additional_properties[key]
 

--- a/testcase2owl/phyloref/TUMatch.py
+++ b/testcase2owl/phyloref/TUMatch.py
@@ -56,7 +56,9 @@ class TUMatch(Identified):
         """
 
         methods_to_try = list()
+        methods_to_try.append(TUMatch.try_match_by_external_reference)
         methods_to_try.append(TUMatch.try_match_by_binomial_name)
+        methods_to_try.append(TUMatch.try_match_by_specimen_identifier)
 
         for method in methods_to_try:
             ret = method(tunit1, tunit2)
@@ -67,19 +69,68 @@ class TUMatch(Identified):
         return None
 
     @staticmethod
+    def try_match_by_external_reference(tunit1, tunit2):
+        """ Compare two taxonomic units by looking for identical external references (compared case insensitively). """
+
+        tunit1_extrefs = tunit1.external_references
+        tunit2_extrefs = tunit2.external_references
+
+        for tunit1_extref in tunit1_extrefs:
+            for tunit2_extref in tunit2_extrefs:
+                # We might eventually want to support full URI-to-URI comparisons
+                # here, possibly using the 'uri' package. For now, just lowercase
+                # identical string comparisons are probably good enough.
+                if tunit1_extref.strip() != "" and tunit1_extref.lower().strip() == tunit2_extref.lower().strip():
+                    return TUMatch(
+                        [tunit1, tunit2],
+                        "External reference '{!s}' is shared by taxonomic unit {!s} and {!s}".format(
+                            tunit1_extref.lower(),
+                            tunit1,
+                            tunit2
+                        )
+                    )
+
+        return None
+
+    @staticmethod
     def try_match_by_binomial_name(tunit1, tunit2):
+        """ Compare two taxonomic units by looking for identical binomial names. """
         tunit1_scnames = tunit1.scientific_names
         tunit2_scnames = tunit2.scientific_names
 
         for tunit1_scname in tunit1_scnames:
             for tunit2_scname in tunit2_scnames:
-                if tunit1_scname.binomial_name == tunit2_scname.binomial_name:
+                if tunit1_scname.binomial_name is None or tunit2_scname.binomial_name is None:
+                    continue
+
+                if tunit1_scname.binomial_name.strip() != "" and tunit1_scname.binomial_name.strip() == tunit2_scname.binomial_name.strip():
                     return TUMatch(
                         [tunit1, tunit2],
                         u"Scientific name '{0}' of taxonomic unit '{1}' and scientific name '{2}' of taxonomic unit '{3}' share the same binomial name: '{4}'".format(
                             tunit1_scname, tunit1,
                             tunit2_scname, tunit2,
                             tunit1_scname.binomial_name
+                        )
+                    )
+
+        return None
+
+    @staticmethod
+    def try_match_by_specimen_identifier(tunit1, tunit2):
+        """ Compare two taxonomic units by looking for matching specimen identifiers. """
+        tunit1_specimens = tunit1.specimens
+        tunit2_specimens = tunit2.specimens
+
+        for tunit1_specimen in tunit1_specimens:
+            for tunit2_specimen in tunit2_specimens:
+
+                if tunit1_specimen.identifier.strip() != "" and tunit1_specimen.identifier.strip() == tunit2_specimen.identifier.strip():
+                    return TUMatch(
+                        [tunit1, tunit2],
+                        "Specimen identifier '{!s}' is shared by taxonomic unit {!s} and {!s}".format(
+                            tunit1_specimen.identifier.strip(),
+                            tunit1,
+                            tunit2
                         )
                     )
 

--- a/testcase2owl/phyloref/TaxonomicUnit.py
+++ b/testcase2owl/phyloref/TaxonomicUnit.py
@@ -299,7 +299,7 @@ class Specimen(object):
     Represents a single specimen included in a taxonomic unit.
     """
 
-    def __init__(self, props):
+    def __init__(self, props=dict()):
         """ Create a Specimen based on key-value properties.
 
         :param props: A dict consisting of key-value properties.
@@ -308,10 +308,6 @@ class Specimen(object):
 
         if '@type' not in self.properties:
             self.properties['@type'] = 'dwc:MaterialSample'
-
-    def __init__(self):
-        """ Create a blank Specimen. """
-        self.__init__(dict())
 
     def __str__(self):
         """ Return a string representation of this Specimen. """
@@ -325,10 +321,10 @@ class Specimen(object):
     def from_jsonld(jsonld):
         """ Read a Specimen from a JSON-LD object and return it. """
         sp = Specimen()
-        sp.load_from_json(jsonld)
+        sp.load_from_jsonld(jsonld)
         return sp
 
-    def as_json(self):
+    def as_jsonld(self):
         """ Return this Specimen as a JSON-LD object. """
         return self.properties
 

--- a/testcase2owl/testcase2owl.py
+++ b/testcase2owl/testcase2owl.py
@@ -127,7 +127,7 @@ try:
             )
 
 except PhyloreferenceTestCase.TestCaseException as e:
-    sys.stderr.write("Could not read '{0}': {1!s}\n".format(input_file, e))
+    sys.stderr.write("\nCould not read input stream '{0}': {1!s}\n".format(input_file, e))
     exit(1)
 
 if FLAG_VERBOSE:

--- a/testcase2owl/tests/test_taxonomic_units.py
+++ b/testcase2owl/tests/test_taxonomic_units.py
@@ -1,0 +1,50 @@
+"""
+Test the code underlying taxonomic units and taxonomic unit matching.
+"""
+
+# Running py.test won't add the current path to the directory -- in order
+# to run this test, you need to run `python -m pytest tests/`.
+from phyloref.TaxonomicUnit import Specimen
+
+
+def test_specimen_identifiers():
+    # Parse a Darwin Core Triplets and make sure it is parsed correctly.
+    specimen = Specimen()
+    specimen.identifier = 'MVZ:Herp:148929'
+    assert specimen.identifier == 'MVZ:Herp:148929'
+    assert specimen.properties.get('occurrenceID') == 'MVZ:Herp:148929'
+    assert specimen.properties.get('institutionCode') == 'MVZ'
+    assert specimen.properties.get('collectionCode') == 'Herp'
+    assert specimen.properties.get('catalogNumber') == '148929'
+
+    # Parse a Darwin Code Double and make sure it is parsed correctly.
+    specimen.identifier = 'MVZ:148929'
+    assert specimen.identifier == 'MVZ:148929'
+    assert specimen.properties.get('occurrenceID') == 'MVZ:148929'
+    assert specimen.properties.get('institutionCode') == 'MVZ'
+    assert specimen.properties.get('collectionCode') is None
+    assert specimen.properties.get('catalogNumber') == '148929'
+
+    # Parse a raw catalog number as a catalog number.
+    specimen.identifier = '148929'
+    assert specimen.identifier == '148929'
+    assert specimen.properties.get('occurrenceID') == '148929'
+    assert specimen.properties.get('institutionCode') is None
+    assert specimen.properties.get('collectionCode') is None
+    assert specimen.properties.get('catalogNumber') == '148929'
+
+    # Make sure URNs are not treated as Darwin Core Triplets.
+    specimen.identifier = 'urn:lsid:biocol.org:col:34777' # Actually a reference to the MVZ
+    assert specimen.identifier == 'urn:lsid:biocol.org:col:34777'
+    assert specimen.properties.get('occurrenceID') == 'urn:lsid:biocol.org:col:34777'
+    assert specimen.properties.get('institutionCode') is None
+    assert specimen.properties.get('collectionCode') is None
+    assert specimen.properties.get('catalogNumber') is None
+
+    # Make sure that URLs are not treated as Darwin Core Triplets.
+    specimen.identifier = 'http://arctos.database.museum/guid/MVZ:Herp:148929?seid=886464'
+    assert specimen.identifier == 'http://arctos.database.museum/guid/MVZ:Herp:148929?seid=886464'
+    assert specimen.properties.get('occurrenceID') == 'http://arctos.database.museum/guid/MVZ:Herp:148929?seid=886464'
+    assert specimen.properties.get('institutionCode') is None
+    assert specimen.properties.get('collectionCode') is None
+    assert specimen.properties.get('catalogNumber') is None

--- a/testcases/Fisher et al, 2007/paper.json
+++ b/testcases/Fisher et al, 2007/paper.json
@@ -17,10 +17,44 @@
 
                 "additionalNodeProperties": {
                     "Arthrocormus schimperi": {
-                        "expectedPhyloreferenceNamed": ["Arthrocormus"]
+                        "expectedPhyloreferenceNamed": ["Arthrocormus"],
+                        "representsTaxonomicUnits": [{
+                            "includesSpecimens": [{
+                                "catalogNumber": "Mishler 7/24/98 (5)"  
+                            }]
+                        }]
                     },
                     "Exodictyon incrassatum": {
-                        "expectedPhyloreferenceNamed": ["Exodictyon"]
+                        "expectedPhyloreferenceNamed": ["Exodictyon"],
+                        "representsTaxonomicUnits": [{
+                            "includesSpecimens": [{
+                                "catalogNumber": "Wall 2527, Fiji (uc)"
+                            }]
+                        }]
+                    },
+                    "Exostratum blumii 243": {
+                        "comment": "The paper does not tell us which specimen ID goes with which node, so I've assigned both specmen IDs to both nodes. -- GGV",
+                        "representsTaxonomicUnits": [{
+                            "includesSpecimens": [{
+                                "catalogNumber": "Mishler 7/24/98(3)"
+                            }]
+                        }, {
+                            "includesSpecimens": [{
+                                "catalogNumber": "Mishler 7/26/98(1)"
+                            }]
+                        }]
+                    },
+                    "Exostratum blumii 245": {
+                        "comment": "The paper does not tell us which specimen ID goes with which node, so I've assigned both specmen IDs to both nodes. -- GGV",
+                        "representsTaxonomicUnits": [{
+                            "includesSpecimens": [{
+                                "catalogNumber": "Mishler 7/24/98(3)"
+                            }]
+                        }, {
+                            "includesSpecimens": [{
+                                "catalogNumber": "Mishler 7/26/98(1)"
+                            }]
+                        }]
                     }
                 }
 	}],
@@ -250,6 +284,11 @@
                     "scientificName": "Type: Arthrocormus schimperi (Dozy & Molk.) Dozy & Molk. (= Mielichhoferia schimperi Dozy & Molk.), Musci Frond. Ined. Archip. Ind. 75. (1846) -- Mishler 7/24/98 (5) Queensland, Australia (UC)",
                     "binomialName": "Arthrocormus schimperi"
                 }]
+            }, {
+                "includesSpecimens": [{
+                    "label": "Mishler 7/24/98 (5) Queensland, Australia (UC)",
+                    "catalogNumber": "Mishler 7/24/98 (5)"  
+                }]   
             }]
         }],
         "externalSpecifiers": [{
@@ -273,12 +312,9 @@
             }]
         }, {
             "referencesTaxonomicUnits": [{
-                "specimens": [{
-                    "label": "Mishler 7/24/98(3), Queensland, Australia (uc)"
-                }],
-                "scientificNames": [{
-                    "scientificName": "Exostratum blumii (Nees ex Hampe) L.T. Ellis",
-                    "comment": "As per table 1 in the paper, which identifies this specimen."
+                "includesSpecimens": [{
+                    "label": "Mishler 7/24/98(3), Queensland, Australia (uc)",
+                    "catalogNumber": "Mishler 7/24/98(3)"
                 }]
             }]
         }],
@@ -299,9 +335,12 @@
             "referencesTaxonomicUnits": [{
                 "scientificNames": [{
                     "scientificName": "Type: Exodictyon Cardot, Rev. Bryol. Lichénol. 26: 6. (1899), excl. parte, emend Ellis in Lindbergia 11: 16 (1985) -- Wall 2527, Fiji (uc)",
-                    "testcase:submittedName": "Exodictyon incrassatum (Mitt.) Cardot",
-                    "binomialName": "Exodictyon incrassatum"
+                    "binomialName": "Exodictyon"
                 }]
+            }, {
+                "includesSpecimens": [{
+                    "catalogNumber": "Wall 2527, Fiji (uc)"
+                }]   
             }]
         }],
         "externalSpecifiers": [{
@@ -334,9 +373,8 @@
         }],
         "externalSpecifiers": [{
             "referencesTaxonomicUnits": [{
-                "scientificNames": [{
-                    "scientificName": "Wall 2527, Fiji (uc) -- Exodictyon incrassatum (Mitt.) Cardot",
-                    "binomialName": "Exodictyon incrassatum"
+                "includesSpecimens": [{
+                    "catalogNumber": "Wall 2527, Fiji (uc)"
                 }]
             }]
         }]


### PR DESCRIPTION
This pull request provides basic specimen matching, allowing taxonomic units that include identically identified specimens to be matched to each other.

Note that I've written code for matching by external reference or specimen identifier, which is synthesized from the occurrenceID or by creating a Darwin Core triplet from "institutionCode:collectionCode:catalogNumber", as suggested by [Guralnick *et al.*, 2014](http://dx.doi.org/10.1371/journal.pone.0114069). However, this pull request only tests comparisons between catalogNumbers, since that's the only specimen identifier used in currently curated studies. We could hold on this pull request until that code is tested, but I think it makes more sense to commit the untested code for now, and open an issue to find a study that will allow us to test the other kinds of specimen matching.

This pull request should be squash-merged if accepted. Closes #8.